### PR TITLE
fix: treesitter parser deprecation notice

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -10,7 +10,7 @@ parser_configs.norg = {
 }
 
 ts_configs.setup({
-  ensure_installed = 'maintained', -- one of "all", "maintained" (parsers with maintainers), or a list of languages
+  ensure_installed = 'all', -- Specify a list of available parsers or "all"
   ignore_install = {}, -- List of parsers to ignore installing
   highlight = {
     enable = true, -- false will disable the whole extension


### PR DESCRIPTION
Replace 'maintained' with 'all' in treesitter:setup parsers.

Deprecation Warning:

```plain
ensure_installed='maintained' will be removed April 30, 2022.
```