### PR TITLE
Nvimtree migrate legacy options and cleanup

### DIFF
--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -130,12 +130,20 @@ nvimtree.setup({
   },
 })
 
-vim.cmd([[
-  highlight NvimTreeNormal guibg=none
-
-  function! DisableST()
-    return " "
-  endfunction
-  au! BufEnter NvimTree setlocal statusline=%!DisableST()
-  \| setlocal cursorline cursorlineopt=both
-]])
+vim.api.nvim_create_augroup('NvimTreeOpts', { clear = true })
+vim.api.nvim_create_autocmd('FileType', {
+  desc = 'Apply local settings to NvimTree buffer',
+  group = 'NvimTreeOpts',
+  pattern = 'NvimTree',
+  callback = function()
+    -- Highlights
+    vim.api.nvim_set_hl(0, 'NvimTreeNormal', { link = 'Normal' })
+    -- Settings
+    vim.opt_local.cursorlineopt = 'both'
+    vim.opt_local.cursorline = true
+    vim.opt_local.statusline = ' '
+    -- Keymaps
+    local opts = { buffer = 0, silent = true, noremap = true }
+    vim.keymap.set('n', '<esc>', '<cmd>q<cr>', opts)
+  end,
+})

--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -47,10 +47,10 @@ nvimtree.setup({
   diagnostics = {
     enable = true,
     icons = {
-      hint = '',
-      info = '',
-      warning = '',
-      error = '',
+      hint = ' ',
+      info = ' ',
+      warning = ' ',
+      error = ' ',
     },
   },
   -- update the focused file on `BufEnter`,

--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -10,7 +10,6 @@ end
 
 --- Globals ---
 
-g.nvim_tree_indent_markers = 1 -- This option shows indent markers when folders are open.
 g.nvim_tree_git_hl = 1 -- Will enable file highlight for git attributes (can be used without the icons).
 g.nvim_tree_highlight_opened_files = 1 -- Will enable folder and file icon highlight for opened files/directories.
 g.nvim_tree_add_trailing = 0 -- Append a trailing slash to folder names. ]]
@@ -96,6 +95,17 @@ nvimtree.setup({
     },
     number = false,
     relativenumber = false,
+  },
+  renderer = {
+    -- This option shows indent markers when folders are open.
+    indent_markers = {
+      enable = true,
+      icons = {
+        corner = '└ ',
+        edge = '│ ',
+        none = '  ',
+      },
+    },
   },
   trash = {
     cmd = 'trash',

--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -10,9 +10,12 @@ end
 
 --- Globals ---
 
-g.nvim_tree_git_hl = 1 -- Will enable file highlight for git attributes (can be used without the icons).
-g.nvim_tree_highlight_opened_files = 1 -- Will enable folder and file icon highlight for opened files/directories.
-g.nvim_tree_add_trailing = 0 -- Append a trailing slash to folder names. ]]
+-- Will enable file highlight for git attributes (can be used without the icons)
+g.nvim_tree_git_hl = 1
+-- Will enable folder and file icon highlight for opened files/directories
+g.nvim_tree_highlight_opened_files = 1
+-- Append a trailing slash to folder names
+g.nvim_tree_add_trailing = 0
 
 --- Setup ---
 
@@ -50,15 +53,11 @@ nvimtree.setup({
       error = '',
     },
   },
-  -- update the focused file on `BufEnter`, un-collapses the folders recursively until it finds the file
+  -- update the focused file on `BufEnter`,
+  -- un-collapses the folders recursively until it finds the file
   update_focused_file = {
-    -- enables the feature
     enable = true,
-    -- update the root directory of the tree to the one of the folder containing the file if the file is not under the current root directory
-    -- only relevant when `update_focused_file.enable` is true
     update_cwd = true,
-    -- list of buffer names / filetypes that will not update the cwd if the file isn't found under the current root directory
-    -- only relevant when `update_focused_file.update_cwd` is true and `update_focused_file.enable` is true
     ignore_list = {},
   },
   -- configuration options for the system open command (`s` in the tree by default)
@@ -78,9 +77,11 @@ nvimtree.setup({
     timeout = 500,
   },
   view = {
-    -- width of the window, can be either a number (columns) or a string in `%`, for left or right side placement
+    -- width of the window, can be either a number (columns)
+    -- or a string in `%`, for left or right side placement
     width = 40,
-    -- height of the window, can be either a number (columns) or a string in `%`, for top or bottom side placement
+    -- height of the window, can be either a number (columns)
+    -- or a string in `%`, for top or bottom side placement
     height = 30,
     -- side of the tree, can be one of 'left' | 'right' | 'top' | 'bottom'
     side = 'right',

--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -69,7 +69,12 @@ nvimtree.setup({
   },
   filters = {
     dotfiles = false,
-    custom = { '.git', 'node_modules', '.cache', '__pycache__' },
+    custom = {
+      '.cache',
+      '.git',
+      '__pycache__',
+      'node_modules',
+    },
   },
   git = {
     enable = true,

--- a/lua/plugins/nvimtree.lua
+++ b/lua/plugins/nvimtree.lua
@@ -2,11 +2,7 @@
 
 local g = vim.g
 
--- Prevent loading if not applicable
-local ok, nvimtree = pcall(require, 'nvim-tree')
-if not ok then
-  return
-end
+nvimtree = require('nvim-tree')
 
 --- Globals ---
 


### PR DESCRIPTION
Migrate plugin globals to setup function according to deprication/migration notice.

- Remove module reference: `pcall` in in favor of `require`
- Cleanup long comments to fit vim `TextWidth`
- Migrate `autocmd` definitions to lua api `nvim_create_autocmd`
