### PR TITLE
fix: add config / migrate to fork `NvChad/nvim-colorizer.lua`

### DIFF
--- a/lua/plugins/colorizer.lua
+++ b/lua/plugins/colorizer.lua
@@ -1,0 +1,26 @@
+-- colorizer.nvim | The fastest Neovim colorizer.
+-- https://github.com/NvChad/nvim-colorizer.lua
+local colorizer_ok, colorizer = pcall(require, 'colorizer')
+if not colorizer_ok then
+  return
+end
+
+colorizer.setup({
+  filetypes = {
+    '*',
+    '!packer',
+    '!popup',
+    '!prompt',
+  },
+  user_default_options = {
+    RGB = true, -- #RGB hex codes
+    RRGGBB = true, -- #RRGGBB hex codes
+    names = false, -- "Name" codes like Blue
+    RRGGBBAA = true, -- #RRGGBBAA hex codes
+    rgb_fn = false, -- CSS rgb() and rgba() functions
+    hsl_fn = false, -- CSS hsl() and hsla() functions
+    css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
+    css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
+    mode = 'background', -- Set the display mode.
+  },
+})

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -280,8 +280,9 @@ return packer.startup({
     })
 
     use({ -- A high-performance color highlighter
-      'norcalli/nvim-colorizer.lua',
+      'NvChad/nvim-colorizer.lua',
       config = get_setup('plugins.colorizer'),
+      event = { 'BufRead', 'BufWinEnter' },
     })
 
     use({ -- Highlight, list and search todo comments


### PR DESCRIPTION
Previously added to packer plugin list without a valid configuration file, and utilized the original repository.

- https://github.com/norcalli/nvim-colorizer.lua

The [NvChad](https://github.com/NvChad/NvChadhttps://github.com/NvChad/NvChad) team current manages a fork of the repository that is more up-to-date. Which also includes a new structure for user configuration.