### PR TITLE
More cleanup on `plugins.nvimtree`

### DIFF
--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -37,7 +37,6 @@ nvimtree.setup({
   },
   view = {
     width = 40,
-    height = 30,
     side = 'right',
     mappings = {
       custom_only = false,

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -29,10 +29,10 @@ nvimtree.setup({
   filters = {
     dotfiles = false,
     custom = {
-      '.cache',
-      '.git',
-      '__pycache__',
-      'node_modules',
+      '.cache', -- General cache directory
+      '.git', -- Git repository directory
+      '__pycache__', -- Python cache directory
+      'node_modules', -- Node module directory
     },
   },
   view = {

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -62,14 +62,7 @@ vim.api.nvim_create_autocmd('FileType', {
   group = 'NvimTreeBuffer',
   pattern = 'NvimTree',
   callback = function()
-    -- Highlights
+    -- Link NvimTree normal to higroup Normal
     vim.api.nvim_set_hl(0, 'NvimTreeNormal', { link = 'Normal' })
-    -- Settings
-    vim.opt_local.cursorlineopt = 'both'
-    vim.opt_local.cursorline = true
-    vim.opt_local.statusline = ' '
-    -- Keymaps
-    local opts = { buffer = 0, silent = true, noremap = true }
-    vim.keymap.set('n', '<esc>', '<cmd>q<cr>', opts)
   end,
 })

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -50,6 +50,9 @@ nvimtree.setup({
     indent_markers = {
       enable = true,
     },
+    icons = {
+      git_placement = 'after',
+    },
   },
 })
 

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -9,8 +9,6 @@ end
 
 nvimtree.setup({
   sort_by = 'case_sensitive',
-  open_on_setup = false,
-  open_on_tab = false,
   sync_root_with_cwd = true,
   disable_netrw = true,
   hijack_netrw = true,
@@ -20,33 +18,13 @@ nvimtree.setup({
     enable = true,
     auto_open = true,
   },
-  actions = {
-    change_dir = {
-      enable = true,
-      global = false,
-    },
-    open_file = {
-      quit_on_open = false,
-      resize_window = false,
-    },
-  },
   diagnostics = {
     enable = true,
-    icons = {
-      hint = ' ',
-      info = ' ',
-      warning = ' ',
-      error = ' ',
-    },
   },
   update_focused_file = {
     enable = true,
     update_root = true,
     ignore_list = {},
-  },
-  system_open = {
-    cmd = nil,
-    args = {},
   },
   filters = {
     dotfiles = false,
@@ -57,14 +35,7 @@ nvimtree.setup({
       'node_modules',
     },
   },
-  git = {
-    enable = true,
-    ignore = true,
-    timeout = 500,
-  },
   view = {
-    number = false,
-    relativenumber = false,
     width = 40,
     height = 30,
     side = 'right',
@@ -74,22 +45,12 @@ nvimtree.setup({
     },
   },
   renderer = {
-    add_trailing = false,
+    group_empty = true,
     highlight_git = true,
     highlight_opened_files = '2',
-    group_empty = true,
     indent_markers = {
       enable = true,
-      icons = {
-        corner = '└ ',
-        edge = '│ ',
-        none = '  ',
-      },
     },
-  },
-  trash = {
-    cmd = 'trash',
-    require_confirm = true,
   },
 })
 

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -11,8 +11,9 @@ nvimtree.setup({
   sort_by = 'case_sensitive',
   sync_root_with_cwd = true,
   disable_netrw = true,
-  hijack_netrw = true,
   hijack_cursor = true,
+  hijack_netrw = true,
+  hijack_unnamed_buffer_when_opening = true,
   ignore_ft_on_setup = {},
   hijack_directories = {
     enable = true,

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -1,7 +1,7 @@
 -- nvim-tree | file browser for neovim
--- URL: https://github.com/kyazdani42/nvim-tree.lua
-local status_ok, nvimtree = pcall(require, 'nvim-tree')
-if not status_ok then
+-- https://github.com/kyazdani42/nvim-tree.lua
+local nvimtree_ok, nvimtree = pcall(require, 'nvim-tree')
+if not nvimtree_ok then
   return
 end
 


### PR DESCRIPTION
- Fix error with `view.height` field
- Remove setup fields that match default config
- Remove unnecessary autocmd settings for nvimtree buffer