### PR TITLE
ci: revert workflow triggers to reduce unnecessary checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,13 @@
 name: Lint/Style checking
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
 
 jobs:
   luacheck:


### PR DESCRIPTION
Only run on push to main branch or pull requests that target the main
branch. This should prevent new pull requests from running the workflows
twice from both the push and pull-request events being triggered.
