### PR TITLE
Fix lazy config

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -24,12 +24,11 @@ require("lazy").setup({
   },
   change_detection = { notify = false },
   defaults = { lazy = true },
+  install = { colorscheme = { "vscode", "default" } },
+  ui = { border = vim.g.border },
   dev = {
     path = "~/Projects",
     patterns = { "daephx" },
-  },
-  install = {
-    colorscheme = { "vscode", "default" },
   },
   performance = {
     rtp = {
@@ -46,9 +45,6 @@ require("lazy").setup({
         "zipPlugin",
       },
     },
-  },
-  ui = {
-    border = vim.g.border,
   },
 })
 

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -66,7 +66,13 @@ map("n", "<leader>pu", "<cmd>Lazy update<CR>", { desc = "Update plugins" })
 --- Autocmds ---
 
 vim.api.nvim_create_autocmd("BufRead", {
-  desc = "Prevent lazy lockfile from being modified",
+  desc = "Prevent formatting errors in neovim lazy lockfile",
   pattern = "lazy-lock.json",
-  command = "setlocal readonly",
+  callback = function()
+    vim.b.autoformat = false
+    vim.b.editorconfig = false
+    vim.bo.binary = true
+    vim.bo.fixendofline = false
+    vim.wo.spell = false
+  end,
 })

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -50,6 +50,8 @@ require("lazy").setup({
 
 --- Keymaps ---
 
+local map = vim.keymap.set
+
 map("n", "<leader>pb", "<cmd>Lazy build<CR>", { desc = "Build plugins" })
 map("n", "<leader>pc", "<cmd>Lazy clean<CR>", { desc = "Clean plugins" })
 map("n", "<leader>ph", "<cmd>Lazy health<CR>", { desc = "Healthcheck plugins" })


### PR DESCRIPTION
- fix: improve autocmd for lazy-lock buffer options
- fix: use local variable to prevent linting error
- style: change order of lazy setup options fields