### PR TITLE
fix(dashboard): change icons due to shifted cursor position

### DIFF
--- a/lua/plugins/dashboard.lua
+++ b/lua/plugins/dashboard.lua
@@ -56,7 +56,7 @@ return {
           action = "Telescope projects",
         },
         {
-          icon = "󰆓",
+          icon = "",
           desc = "Applications",
           keymap = "SPC p m",
           key = "m",
@@ -77,7 +77,7 @@ return {
           action = "Telescope vimfiles",
         },
         {
-          icon = "󰅗",
+          icon = "",
           desc = "Exit",
           keymap = "",
           key = "q",


### PR DESCRIPTION
The previous nerdfont icons have a longer escaped hex value and when measuring the string length of a single icon, they equate to a value of greater than one. Which causes issues with dashboard.nvim logic for padding and/or where the display the cursor for the active selection.

The new cursors have a hex length of 4 and don't suffer from the same issue while still representing the category of their respective commands.