### PR TITLE
Cleanup language configs/lsp

### DIFF
--- a/after/ftplugin/ps1.lua
+++ b/after/ftplugin/ps1.lua
@@ -4,3 +4,4 @@ vim.opt_local.expandtab = true
 vim.opt_local.shiftwidth = 4
 vim.opt_local.softtabstop = 4
 vim.opt_local.tabstop = 4
+vim.opt_local.textwidth = 120

--- a/lua/plugins/autopairs.lua
+++ b/lua/plugins/autopairs.lua
@@ -27,6 +27,7 @@ return {
         "confirm_done",
         cmp_npairs.on_confirm_done({
           filetypes = {
+            ps1 = false,
             ["*"] = { -- "*" alias to all filetypes
               ["("] = {
                 kind = {

--- a/lua/plugins/lsp/null-ls.lua
+++ b/lua/plugins/lsp/null-ls.lua
@@ -55,9 +55,10 @@ null_ls.setup({
     formatting.fish_indent,
 
     -- Python
-    diagnostics.flake8.with({ extra_args = { "--max-line-length=88" } }),
     formatting.black.with({ extra_args = { "--fast", "--quiet" } }),
-    formatting.isort,
+
+    diagnostics.ruff,
+    formatting.ruff,
 
     -- Golang
     formatting.gofmt,

--- a/lua/plugins/lsp/null-ls.lua
+++ b/lua/plugins/lsp/null-ls.lua
@@ -55,7 +55,7 @@ null_ls.setup({
     formatting.fish_indent,
 
     -- Python
-    formatting.black.with({ extra_args = { "--fast", "--quiet" } }),
+    formatting.black,
 
     diagnostics.ruff,
     formatting.ruff,

--- a/lua/plugins/lsp/settings/powershell_es.lua
+++ b/lua/plugins/lsp/settings/powershell_es.lua
@@ -1,0 +1,29 @@
+-- powershell_es: Language-server configuration
+-- https://github.com/PowerShell/PowerShellEditorServices
+
+return {
+  settings = {
+    powershell = {
+      codeFormatting = {
+        Preset = "Stroustrup",
+        addWhitespaceAroundPipe = true,
+        alignPropertyValuePairs = false,
+        autoCorrectAliases = true,
+        avoidSemicolonsAsLineTerminators = true,
+        ignoreOneLineBlock = true,
+        newLineAfterCloseBrace = true,
+        newLineAfterOpenBrace = true,
+        openBraceOnSameLine = true,
+        pipelineIndentationStyle = "IncreaseIndentationForFirstPipeline",
+        useCorrectCasing = true,
+        whitespaceAfterSeparator = true,
+        whitespaceAroundOperator = true,
+        whitespaceBeforeOpenParen = true,
+        whitespaceBetweenParameters = false,
+      },
+      scriptAnalysis = {
+        settingsPath = "PSScriptAnalyzerSettings.psd1",
+      },
+    },
+  },
+}

--- a/lua/plugins/lsp/settings/powershell_es.lua
+++ b/lua/plugins/lsp/settings/powershell_es.lua
@@ -1,6 +1,17 @@
 -- powershell_es: Language-server configuration
 -- https://github.com/PowerShell/PowerShellEditorServices
 
+vim.api.nvim_create_autocmd("LspAttach", {
+  desc = "Disable highlighting for powershell_es semantic tokens",
+  group = vim.api.nvim_create_augroup("LspAttach_PowerShellES", {}),
+  callback = function(ev)
+    local client = vim.lsp.get_client_by_id(ev.data.client_id)
+    if client.name == "powershell_es" then
+      client.server_capabilities.semanticTokensProvider = nil
+    end
+  end,
+})
+
 return {
   settings = {
     powershell = {

--- a/lua/plugins/lsp/settings/taplo.lua
+++ b/lua/plugins/lsp/settings/taplo.lua
@@ -1,0 +1,22 @@
+-- taplo: A TOML toolkit written in Rust
+-- https://github.com/tamasfe/taplo
+
+return {
+  settings = {
+    evenBetterToml = {
+      schema = {
+        enabled = true,
+        repositoryEnabled = true,
+        repositoryUrl = "https://taplo.tamasfe.dev/schema_index.json",
+      },
+      cachePath = vim.fn.stdpath("cache") .. "/taplo",
+      formatter = {
+        alignEntries = false,
+        allowedBlankLines = 1,
+        indentEntries = false,
+        indentTables = false,
+        reorderKeys = false,
+      },
+    },
+  },
+}

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -28,7 +28,6 @@ return {
         "emmet_ls",
         "gopls",
         "html",
-        "jdtls",
         "jsonls",
         "lua_ls",
         "pyright",

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -34,7 +34,6 @@ return {
         "rust_analyzer",
         "taplo",
         "yamlls",
-        "zk",
       },
     },
   },

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -44,7 +44,6 @@ return {
       ensure_installed = {
         "black",
         "eslint_d",
-        "flake8",
         "isort",
         "luacheck",
         "markdownlint",


### PR DESCRIPTION
- Adds after/ftplugin for powershell (ps1) scripts
- Adds configuration for powershell_es and taplo
- Disables semantic tokens for powershell_es due to highlighting errors
- Disables param auto-pairs for powershell (ps1) scripts
- Disables auto install of lsp servers, jdtls, zk
- Removes builtins for null-ls, replaces flake8 w/ ruff