### PR TITLE
fix(lsp): disable lua_ls diagnostics for incomplete signature docs

### DIFF
--- a/lua/plugins/lsp/settings/lua_ls.lua
+++ b/lua/plugins/lsp/settings/lua_ls.lua
@@ -25,9 +25,12 @@ return {
           ["unbalanced"] = "Opened",
           ["unused"] = "Opened",
         },
-        unusedLocalExclude = { "_*" },
-        disable = { "lowercase-global" },
+        disable = {
+          "incomplete-signature-doc",
+          "lowercase-global",
+        },
         globals = { "vim" },
+        unusedLocalExclude = { "_*" },
       },
       format = {
         enable = false,


### PR DESCRIPTION
Adds disable/exclude rule for lua_ls diagnostics to prevent annoying requirement to docstring every function.

Also changes sorting of these exceptions to alphabetize disable/globals/unused.