### PR TITLE
refactor(lsp): rework lsp document highlighting

### DIFF
--- a/lua/plugins/lsp/handlers/highlight.lua
+++ b/lua/plugins/lsp/handlers/highlight.lua
@@ -1,11 +1,12 @@
 local M = {}
 
+local augroup = vim.api.nvim_create_augroup("LspDocumentHighlight", { clear = true })
+
 -- Highlight references under cursor
 ---@param client table
 ---@param bufnr integer
 M.enable_document_highlighting = function(client, bufnr)
   if client.supports_method("textDocument/documentHighlight") then
-    local augroup = vim.api.nvim_create_augroup("LspDocumentHighlight", { clear = true })
     vim.api.nvim_create_autocmd({ "CursorHold" }, {
       buffer = bufnr,
       desc = "Apply LSP document reference highlighting on CursorHold",

--- a/lua/plugins/lsp/handlers/highlight.lua
+++ b/lua/plugins/lsp/handlers/highlight.lua
@@ -6,16 +6,6 @@ local M = {}
 M.enable_document_highlighting = function(client, bufnr)
   if client.supports_method("textDocument/documentHighlight") then
     local augroup = vim.api.nvim_create_augroup("LspDocumentHighlight", { clear = true })
-    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
-      desc = "Link LSP document reference highlight groups to IncSearch",
-      group = augroup,
-      callback = function()
-        local opts = { link = "IncSearch", bold = true }
-        vim.api.nvim_set_hl(0, "LspReferenceRead", opts)
-        vim.api.nvim_set_hl(0, "LspReferenceText", opts)
-        vim.api.nvim_set_hl(0, "LspReferenceWrite", opts)
-      end,
-    })
     vim.api.nvim_create_autocmd({ "CursorHold" }, {
       buffer = bufnr,
       desc = "Apply LSP document reference highlighting on CursorHold",

--- a/lua/plugins/lsp/handlers/highlight.lua
+++ b/lua/plugins/lsp/handlers/highlight.lua
@@ -2,7 +2,8 @@ local M = {}
 
 local augroup = vim.api.nvim_create_augroup("LspDocumentHighlight", { clear = true })
 
--- Highlight references under cursor
+-- Set autocmd for the current buffer to enable and clear document highlight.
+-- Only sets if the active client supported the textDocument/documentHighlight method.
 ---@param client table
 ---@param bufnr integer
 M.enable_document_highlighting = function(client, bufnr)

--- a/lua/plugins/lsp/handlers/highlight.lua
+++ b/lua/plugins/lsp/handlers/highlight.lua
@@ -14,7 +14,7 @@ M.enable_document_highlighting = function(client, bufnr)
       group = augroup,
       callback = vim.lsp.buf.document_highlight,
     })
-    vim.api.nvim_create_autocmd({ "CursorMoved", "InsertEnter", "CursorMovedI" }, {
+    vim.api.nvim_create_autocmd({ "BufLeave", "CursorMoved", "CursorMovedI", "InsertEnter" }, {
       buffer = bufnr,
       desc = "Disable LSP document reference highlighting on CursorMoved",
       group = augroup,


### PR DESCRIPTION
Removes autocmd that link the following highlight groups to `IncSearch`.
Prefer to use the colorschemes default settings or allow the user to
override these values within the colorscheme settings.

- `LspReferenceRead`
- `LspReferenceText`
- `LspReferenceWrite`