### PR TITLE
feat(lualine): use modified vscode.nvim theme

### DIFF
--- a/lua/lualine/themes/vscode.lua
+++ b/lua/lualine/themes/vscode.lua
@@ -1,9 +1,11 @@
 -- Copyright (c) 2020-2021 Mofiqul Islam
 -- MIT license, see LICENSE for more details.
+local config = require("vscode.config")
 local vscode = {}
 local colors = {}
 
 if vim.o.background == "dark" then
+  colors.inactive = "#666666"
   colors.bg = "#262626"
   colors.bg2 = "#373737"
   colors.fg = "#ffffff"
@@ -13,8 +15,8 @@ if vim.o.background == "dark" then
   colors.lightblue = "#5CB6F8"
   colors.yellow = "#ffaf00"
   colors.pink = "#DDB6F2"
-  colors.inactive = "#666666"
 else
+  colors.inactive = "#888888"
   colors.bg = "#F5F5F5"
   colors.bg2 = "#E4E4E4"
   colors.fg = "#343434"
@@ -24,49 +26,47 @@ else
   colors.lightblue = "#0451A5"
   colors.yellow = "#ffaf00"
   colors.pink = "#FFA3A3"
-  colors.inactive = "#888888"
 end
 
 vscode.normal = {
   a = { fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.blue, gui = "bold" },
-  b = { fg = colors.blue, bg = colors.bg2 },
-  c = { fg = colors.fg, bg = colors.bg },
+  b = { fg = colors.blue, bg = config.opts.transparent and "NONE" or colors.bg2 },
+  c = { fg = colors.fg, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 vscode.visual = {
-  a = { fg = colors.bg, bg = colors.yellow, gui = "bold" },
-  b = { fg = colors.yellow, bg = colors.bg2 },
-  c = { fg = colors.fg, bg = colors.bg },
+  a = { fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.yellow, gui = "bold" },
+  b = { fg = colors.yellow, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 vscode.replace = {
   a = { fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.red, gui = "bold" },
-  b = { fg = colors.red, bg = colors.bg2 },
-  c = { fg = colors.fg, bg = colors.bg },
+  b = { fg = colors.red, bg = config.opts.transparent and "NONE" or colors.bg2 },
+  c = { fg = colors.fg, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 vscode.insert = {
   a = { fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.green, gui = "bold" },
-  b = { fg = colors.green, bg = colors.bg2 },
-  c = { fg = colors.fg, bg = colors.bg },
+  b = { fg = colors.green, bg = config.opts.transparent and "NONE" or colors.bg2 },
+  c = { fg = colors.fg, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 vscode.terminal = {
   a = { fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.green, gui = "bold" },
-  b = { fg = colors.fg, bg = colors.bg2 },
-  c = { fg = colors.fg, bg = colors.bg },
+  b = { fg = colors.fg, bg = config.opts.transparent and "NONE" or colors.bg2 },
+  c = { fg = colors.fg, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 vscode.command = {
   a = { fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.pink, gui = "bold" },
-  b = { fg = colors.pink, bg = colors.bg2 },
-  c = { fg = colors.fg, bg = colors.bg },
+  b = { fg = colors.pink, bg = config.opts.transparent and "NONE" or colors.bg2 },
+  c = { fg = colors.fg, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 vscode.inactive = {
   a = { fg = colors.fg, bg = colors.bg, gui = "bold" },
-  b = { fg = colors.inactive, bg = colors.bg },
-  c = { fg = colors.inactive, bg = colors.bg },
+  b = { fg = colors.inactive, bg = config.opts.transparent and "NONE" or colors.bg },
+  c = { fg = colors.inactive, bg = config.opts.transparent and "NONE" or colors.bg },
 }
 
 return vscode


### PR DESCRIPTION
This is now more inline with the current configuration provided by vscode.nvim with a few tweaks for section_a foreground text, but ultimately reintroduces the use of transparent status/tabline which was previously locally overwritten.