### PR TITLE
fix: set filetype association for rofi-rasi

### DIFF
--- a/lua/config/filetypes.lua
+++ b/lua/config/filetypes.lua
@@ -21,6 +21,7 @@ vim.filetype.add({
     pandoc = "pandoc",
     pde = "processing",
     prettierrc = "jsonc",
+    rasi = "rasi",
     scm = "scheme",
     stylelintrc = "json",
     tex = "tex",


### PR DESCRIPTION
Allow treesitter parser to detect rofi's rasi config filetype.