### PR TITLE
fix(lualine): illegal character in lualine component: lsp_info

### DIFF
--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -56,7 +56,6 @@ local diagnostics = {
 
 local lsp_info = {
   "lsp_info",
-  max_size = 80,
   icon = { "", align = "right" },
   client_names = {
     ["arduino_language_server"] = "arduino_ls",


### PR DESCRIPTION
For some reason, defining the `max_size` with the current configuration causes an error within lualine stating the use of an illegal character. I tried opening an issue with the repository maintainer but my issue was deemed insufficient for reproduction. Though it appears to still be present as an edge case error.

While it would be nice to define the `max_size` value to prevent messages from overflowing the whole statusline, this bug needs to squashed first because it is extremely invasive when trying to do work.