### PR TITLE
docs(lazy): add explicit types hints to all plugin spec tables

### DIFF
--- a/lua/plugins/autopairs.lua
+++ b/lua/plugins/autopairs.lua
@@ -1,6 +1,7 @@
 -- nvim-autopairs | autopairs for neovim written by lua
 -- https://github.com/windwp/nvim-autopairs
 
+---@type LazyPluginSpec
 return {
   "windwp/nvim-autopairs",
   event = { "InsertEnter" },

--- a/lua/plugins/barbecue.lua
+++ b/lua/plugins/barbecue.lua
@@ -1,6 +1,7 @@
 -- barbecue.nvim | A VS Code like winbar for Neovim
 -- https://github.com/utilyre/barbecue.nvim
 
+---@type LazyPluginSpec
 return {
   "utilyre/barbecue.nvim",
   name = "barbecue",

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -89,6 +89,7 @@ local format_source_labels = function(entry)
   return source_labels[entry.source.name]
 end
 
+---@type LazyPluginSpec
 return {
   "hrsh7th/nvim-cmp",
   event = { "InsertEnter", "CmdlineEnter" },

--- a/lua/plugins/colorizer.lua
+++ b/lua/plugins/colorizer.lua
@@ -1,6 +1,7 @@
 -- colorizer.nvim | The fastest Neovim colorizer.
 -- https://github.com/NvChad/nvim-colorizer.lua
 
+---@type LazyPluginSpec
 return {
   "NvChad/nvim-colorizer.lua",
   event = { "BufReadPost", "BufNewFile" },

--- a/lua/plugins/colors/gruvbox.lua
+++ b/lua/plugins/colors/gruvbox.lua
@@ -1,6 +1,7 @@
 -- Lua port of the most famous vim colorscheme
 -- https://github.com/ellisonleao/gruvbox.nvim
 
+---@type LazyPluginSpec
 return {
   "ellisonleao/gruvbox.nvim",
   event = { "ColorSchemePre" },

--- a/lua/plugins/colors/sakura.lua
+++ b/lua/plugins/colors/sakura.lua
@@ -1,6 +1,7 @@
 -- Sakura.nvim | Nice color scheme for neovim
 -- https://github.com/numToStr/Sakura.nvim
 
+---@type LazyPluginSpec
 return {
   "numtostr/sakura.nvim",
   event = { "ColorSchemePre" },

--- a/lua/plugins/colors/tokyonight.lua
+++ b/lua/plugins/colors/tokyonight.lua
@@ -1,6 +1,7 @@
 -- tokyonight.nvim | A clean, dark Neovim theme written in Lua
 -- https://github.com/folke/tokyonight.nvim
 
+---@type LazyPluginSpec
 return {
   "folke/tokyonight.nvim",
   event = { "ColorSchemePre" },

--- a/lua/plugins/colors/vscode.lua
+++ b/lua/plugins/colors/vscode.lua
@@ -1,6 +1,7 @@
 -- Neovim/Vim color scheme inspired by Dark+ and Light+
 -- https://github.com/Mofiqul/vscode.nvim
 
+---@type LazyPluginSpec
 return {
   "Mofiqul/vscode.nvim",
   event = { "ColorSchemePre" },

--- a/lua/plugins/comment.lua
+++ b/lua/plugins/comment.lua
@@ -19,6 +19,7 @@ local post_hook = function(ctx)
   end
 end
 
+---@type LazyPluginSpec
 return {
   "numToStr/Comment.nvim",
   event = { "BufReadPost", "BufNewFile" },

--- a/lua/plugins/dap/init.lua
+++ b/lua/plugins/dap/init.lua
@@ -1,6 +1,7 @@
 -- nvim-dap | Debug Adapter Protocol client implementation for neovim
 -- https://github.com/mfussenegger/nvim-dap
 
+---@type LazyPluginSpec[]
 return {
   { -- Debug adapter protocol client
     "mfussenegger/nvim-dap",

--- a/lua/plugins/dashboard.lua
+++ b/lua/plugins/dashboard.lua
@@ -1,6 +1,7 @@
 -- Dashboard.nvim | vim dashboard
 -- https://github.com/glepnir/dashboard-nvim
 
+---@type LazyPluginSpec
 return {
   "glepnir/dashboard-nvim",
   event = "UIEnter",

--- a/lua/plugins/diffview.lua
+++ b/lua/plugins/diffview.lua
@@ -1,6 +1,7 @@
 -- Diffview.nvim | tabpage interface for easily cycling through diffs
 -- https://github.com/sindrets/diffview.nvim
 
+---@type LazyPluginSpec
 return {
   "sindrets/diffview.nvim",
   cmd = { "DiffviewOpen", "DiffviewClose", "DiffviewToggleFiles", "DiffviewFocusFiles" },

--- a/lua/plugins/fugitive.lua
+++ b/lua/plugins/fugitive.lua
@@ -1,6 +1,7 @@
 -- vim-fugitive | A Git wrapper so awesome, it should be illegal
 -- https://github.com/tpope/vim-fugitive
 
+---@type LazyPluginSpec
 return {
   "tpope/vim-fugitive",
   event = "VeryLazy",

--- a/lua/plugins/git-conflict.lua
+++ b/lua/plugins/git-conflict.lua
@@ -1,6 +1,7 @@
 -- git-conflict.nvim | Visualise and resolve merge conflicts in neovim
 -- https://github.com/akinsho/git-conflict.nvim
 
+---@type LazyPluginSpec
 return {
   "akinsho/git-conflict.nvim",
   version = "*",

--- a/lua/plugins/gitsigns.lua
+++ b/lua/plugins/gitsigns.lua
@@ -1,6 +1,7 @@
 -- gitsigns.nvim | Git integration for buffers
 -- https://github.com/lewis6991/gitsigns.nvim
 
+---@type LazyPluginSpec
 return {
   "lewis6991/gitsigns.nvim",
   event = { "BufReadPost", "BufNewFile" },

--- a/lua/plugins/guess-indent.lua
+++ b/lua/plugins/guess-indent.lua
@@ -1,6 +1,7 @@
 -- guess-indent | Automatic indentation style detection for Neovim
 -- https://github.com/NMAC427/guess-indent.nvim
 
+---@type LazyPluginSpec
 return {
   "NMAC427/guess-indent.nvim",
   event = { "BufReadPre", "BufNewFile" },

--- a/lua/plugins/hex.lua
+++ b/lua/plugins/hex.lua
@@ -1,6 +1,7 @@
 -- hex.nvim | hex editing done right
 -- https://github.com/RaafatTurki/hex.nvim
 
+---@type LazyPluginSpec
 return {
   "RaafatTurki/hex.nvim",
   cmd = { "HexAssemble", "HexDump", "HexToggle" },

--- a/lua/plugins/hop.lua
+++ b/lua/plugins/hop.lua
@@ -12,6 +12,7 @@ local search_buffer = function()
   require("hop").hint_char1({ current_line_only = false })
 end
 
+---@type LazyPluginSpec
 return {
   "smoka7/hop.nvim",
   version = "*",

--- a/lua/plugins/indent_blankline.lua
+++ b/lua/plugins/indent_blankline.lua
@@ -1,6 +1,7 @@
 -- indent-blankline.nvim | Indent guides for Neovim
 -- https://github.com/lukas-reineke/indent-blankline.nvim
 
+---@type LazyPluginSpec
 return {
   "lukas-reineke/indent-blankline.nvim",
   main = "ibl",

--- a/lua/plugins/lsp/init.lua
+++ b/lua/plugins/lsp/init.lua
@@ -1,6 +1,7 @@
 -- Neovim LSP Configuration (Language Server Protocol)
 -- Setup native lsp using lspconfig helper plugin
 
+---@type LazyPluginSpec[]
 return {
   { -- Initialize language server configuration
     "neovim/nvim-lspconfig",

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -149,6 +149,7 @@ local function client_format(client_name, spinner, series_messages)
   end
 end
 
+---@type LazyPluginSpec[]
 return {
   {
     "nvim-lualine/lualine.nvim",

--- a/lua/plugins/luasnip.lua
+++ b/lua/plugins/luasnip.lua
@@ -1,6 +1,7 @@
 -- LuaSnip | Snippet Engine for Neovim written in Lua.
 -- https://github.com/L3MON4D3/LuaSnip
 
+---@type LazyPluginSpec
 return {
   "L3MON4D3/LuaSnip",
   event = "InsertCharPre",

--- a/lua/plugins/markdown.lua
+++ b/lua/plugins/markdown.lua
@@ -1,5 +1,6 @@
 -- lua/plugins/markdown.lua
 
+---@type LazyPluginSpec[]
 return {
   { -- Nice extra's for markdown documents
     "SidOfc/mkdx",

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -1,6 +1,7 @@
 -- mason.nvim | Portable package manager for Neovim
 -- https://github.com/williamboman/mason.nvim
 
+---@type LazyPluginSpec[]
 return {
   {
     "williamboman/mason.nvim",

--- a/lua/plugins/neogit.lua
+++ b/lua/plugins/neogit.lua
@@ -1,6 +1,7 @@
 -- Neogit | magit for Neovim
 -- https://github.com/TimUntersberger/neogit
 
+---@type LazyPluginSpec
 return {
   "TimUntersberger/neogit",
   cmd = "Neogit",

--- a/lua/plugins/neorg.lua
+++ b/lua/plugins/neorg.lua
@@ -1,6 +1,7 @@
 -- neorg | The future of organizing your life in Neovim
 -- https://github.com/nvim-neorg/neorg
 
+---@type LazyPluginSpec
 return {
   "nvim-neorg/neorg",
   ft = "norg",

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -1,6 +1,7 @@
 -- nvim-tree | file browser for neovim
 -- https://github.com/kyazdani42/nvim-tree.lua
 
+---@type LazyPluginSpec
 return {
   "nvim-tree/nvim-tree.lua",
   cmd = { "NvimTreeOpen", "NvimTreeToggle" },

--- a/lua/plugins/project_nvim.lua
+++ b/lua/plugins/project_nvim.lua
@@ -1,6 +1,7 @@
 -- project_nvim | The superior project management solution for neovim.
 -- https://github.com/ahmedkhalf/project.nvim
 
+---@type LazyPluginSpec
 return {
   "ahmedkhalf/project.nvim",
   name = "project_nvim",

--- a/lua/plugins/session.lua
+++ b/lua/plugins/session.lua
@@ -13,6 +13,7 @@ end
 local delete_session = cmd_wrapper("SessionDelete")
 local save_session = cmd_wrapper("SessionSave")
 
+---@type LazyPluginSpec
 return {
   "rmagatti/auto-session",
   event = "VimEnter",

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -1,6 +1,7 @@
 -- Telescope config | configurations for telescope fuzzy-finder
 -- https://github.com/nvim-telescope/telescope.nvim
 
+---@type LazyPluginSpec
 return {
   "nvim-telescope/telescope.nvim",
   cmd = "Telescope",

--- a/lua/plugins/todo-comments.lua
+++ b/lua/plugins/todo-comments.lua
@@ -1,6 +1,7 @@
 -- todo-comments.nvim | Highlight, list and search todo comments in your projects
 -- https://github.com/folke/todo-comments.nvim
 
+---@type LazyPluginSpec
 return {
   "folke/todo-comments.nvim",
   cmd = { "TodoTrouble", "TodoTelescope" },

--- a/lua/plugins/toggleterm.lua
+++ b/lua/plugins/toggleterm.lua
@@ -49,6 +49,7 @@ local initialize_terminals = function(opts)
   end
 end
 
+---@type LazyPluginSpec
 return {
   "akinsho/toggleterm.nvim",
   version = "*",

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,6 +1,7 @@
 -- nvim-treesitter | Nvim Treesitter configurations and abstraction layer
 -- https://github.com/nvim-treesitter/nvim-treesitter
 
+---@type LazyPluginSpec
 return {
   "nvim-treesitter/nvim-treesitter",
   build = ":TSUpdate",

--- a/lua/plugins/trouble.lua
+++ b/lua/plugins/trouble.lua
@@ -1,6 +1,7 @@
 -- trouble.nvim | pretty diagnostics, references, telescope results
 -- https://github.com/folke/trouble.nvim
 
+---@type LazyPluginSpec
 return {
   "folke/trouble.nvim",
   cmd = { "TroubleToggle", "Trouble" },

--- a/lua/plugins/unception.lua
+++ b/lua/plugins/unception.lua
@@ -1,6 +1,7 @@
 -- nvim-unception | open files from terminal without nesting
 -- https://github.com/samjwill/nvim-unception
 
+---@type LazyPluginSpec
 return {
   "samjwill/nvim-unception",
   enabled = false,

--- a/lua/plugins/undotree.lua
+++ b/lua/plugins/undotree.lua
@@ -1,6 +1,7 @@
 -- The undo history visualizer for VIM
 -- https://github.com/mbbill/undotree
 
+---@type LazyPluginSpec
 return {
   "mbbill/undotree",
   cmd = { "UndotreeShow", "UndotreeToggle" },

--- a/lua/plugins/vim-dirtytalk.lua
+++ b/lua/plugins/vim-dirtytalk.lua
@@ -1,6 +1,7 @@
 -- vim-dirtytalk | Spellcheck dictionary for programmers
 -- https://github.com/psliwka/vim-dirtytalk
 
+---@type LazyPluginSpec
 return {
   "psliwka/vim-dirtytalk",
   build = ":DirtytalkUpdate",

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -1,6 +1,7 @@
 -- Which-key | Configurations for plugin WhichKey.nvim
 -- https://github.com/folke/which-key.nvim
 
+---@type LazyPluginSpec
 return {
   "folke/which-key.nvim",
   version = "*",

--- a/lua/plugins/zen-mode.lua
+++ b/lua/plugins/zen-mode.lua
@@ -30,6 +30,7 @@ local on_open = function(win)
   end
 end
 
+---@type LazyPluginSpec
 return {
   "folke/zen-mode.nvim",
   cmd = "ZenMode",


### PR DESCRIPTION
Adds hints to lazy spec return tables.
This allows CMP/LSP suggestions to suggest proper fields such as `events`, `keys`, `opts`.